### PR TITLE
Added functionality for searching Obsolete terms and terms by their iri string

### DIFF
--- a/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/model/ObsoleteTerm.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/model/ObsoleteTerm.java
@@ -1,0 +1,31 @@
+package uk.ac.ebi.pride.utilities.ols.web.service.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Created by olgavrou on 10/11/2016.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ObsoleteTerm extends Term {
+
+    @JsonProperty("is_obsolete")
+    boolean obsolete;
+
+    public ObsoleteTerm(Identifier iri, String label, String[] description,
+                Identifier shortForm, Identifier oboId, String ontologyName, String score, String ontologyIri,
+                boolean definedOntology,
+                OboDefinitionCitation[] oboDefinitionCitation,
+                Annotation annotation, boolean obsolete) {
+        super(iri, label, description, shortForm, oboId, ontologyName, score, ontologyIri, definedOntology, oboDefinitionCitation, annotation);
+        this.obsolete = obsolete;
+    }
+
+    public boolean isObsolete() {
+        return obsolete;
+    }
+
+    public void setObsolete(boolean obsolete) {
+        this.obsolete = obsolete;
+    }
+}

--- a/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/model/RetrieveTermQuery.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/model/RetrieveTermQuery.java
@@ -1,0 +1,22 @@
+package uk.ac.ebi.pride.utilities.ols.web.service.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Created by olgavrou on 10/11/2016.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RetrieveTermQuery {
+
+    @JsonProperty("_embedded")
+    TermEmbeddedSearchResult response;
+
+    public TermEmbeddedSearchResult getResponse() {
+        return response;
+    }
+
+    public void setResponse(TermEmbeddedSearchResult response) {
+        this.response = response;
+    }
+}

--- a/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/model/SearchResult.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/model/SearchResult.java
@@ -40,6 +40,13 @@ public class SearchResult {
     @JsonProperty("is_defining_ontology")
     boolean definedOntology;
 
+    @JsonProperty("is_obsolete")
+    boolean obsolete;
+
+    @JsonProperty("annotation")
+    Annotation annotation;
+
+
     @JsonProperty("obo_definition_citation")
     OboDefinitionCitation[] oboDefinitionCitation;
 
@@ -117,6 +124,22 @@ public class SearchResult {
 
     public boolean getIsDefiningOntology() {
         return definedOntology;
+    }
+
+    public boolean isObsolete() {
+        return obsolete;
+    }
+
+    public void setObsolete(boolean obsolete) {
+        this.obsolete = obsolete;
+    }
+
+    public Annotation getAnnotation() {
+        return annotation;
+    }
+
+    public void setAnnotation(Annotation annotation) {
+        this.annotation = annotation;
     }
 
     public void setIsDefiningOntology(boolean definedOntology) {

--- a/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/model/Term.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/model/Term.java
@@ -40,9 +40,6 @@ public class Term implements Comparable{
     @JsonProperty("ontology_iri")
     String ontologyIri;
 
-    @JsonProperty("is_obsolete")
-    boolean obsolete;
-
     @JsonProperty("is_defining_ontology")
     boolean definedOntology;
 
@@ -81,10 +78,28 @@ public class Term implements Comparable{
         this.shortForm = shortForm;
         this.oboId = oboId;
         this.ontologyName = ontologyName;
-        this.oboDefinitionCitation = oboDefinitionCitation;
         this.score = score;
         this.ontologyIri = ontologyIri;
         this.definedOntology = definedOntology;
+        this.oboDefinitionCitation = oboDefinitionCitation;
+    }
+
+    public Term(Identifier iri, String label, String[] description,
+                Identifier shortForm, Identifier oboId, String ontologyName, String score, String ontologyIri,
+                boolean definedOntology,
+                OboDefinitionCitation[] oboDefinitionCitation,
+                Annotation annotation) {
+        this.iri = iri;
+        this.label = label;
+        this.description = description;
+        this.shortForm = shortForm;
+        this.oboId = oboId;
+        this.ontologyName = ontologyName;
+        this.score = score;
+        this.ontologyIri = ontologyIri;
+        this.definedOntology = definedOntology;
+        this.oboDefinitionCitation = oboDefinitionCitation;
+        this.annotation = annotation;
     }
 
     public Identifier getIri() {
@@ -145,14 +160,6 @@ public class Term implements Comparable{
 
     public void setOntologyIri(String ontologyIri) {
         this.ontologyIri = ontologyIri;
-    }
-
-    public boolean isObsolete() {
-        return obsolete;
-    }
-
-    public void setObsolete(boolean obsolete) {
-        this.obsolete = obsolete;
     }
 
     public boolean isDefinedOntology() {

--- a/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/model/TermEmbeddedSearchResult.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/model/TermEmbeddedSearchResult.java
@@ -1,0 +1,22 @@
+package uk.ac.ebi.pride.utilities.ols.web.service.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Created by olgavrou on 10/11/2016.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TermEmbeddedSearchResult{
+
+    @JsonProperty("terms")
+    SearchResult[] searchResults;
+
+    public SearchResult[] getSearchResults() {
+        return searchResults;
+    }
+
+    public void setSearchResults(SearchResult[] searchResults) {
+        this.searchResults = searchResults;
+    }
+}

--- a/src/test/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClientTest.java
+++ b/src/test/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClientTest.java
@@ -29,7 +29,7 @@ public class OLSClientTest {
     @Test
     public void testGetTermById() throws Exception {
         Term term = olsClient.getTermById(new Identifier("MS:1001767", Identifier.IdentifierType.OBO), "MS");
-        Assert.assertTrue(term.getLabel().equalsIgnoreCase("nanoACQUITY UPLC System with Technology"));
+        Assert.assertTrue(term.getLabel().equalsIgnoreCase("nanoACQUITY UPLC System with 1D Technology"));
     }
 
 
@@ -239,25 +239,11 @@ public class OLSClientTest {
     }
 
     @Test
-    public void testGetLabelByIri(){
-
-        String customQueryField = new QueryFields.QueryFieldBuilder()
-                .setIri()
-                .build()
-                .toString();
-        olsClient.setQueryField(customQueryField);
-
-        String fieldList = new FieldList.FieldListBuilder()
-                .setLabel()
-                .setIri()
-                .setIsDefiningOntology()
-                .build()
-                .toString();
-        olsClient.setFieldList(fieldList);
+    public void testGetLabelByIriString(){
 
         String iri = "http://www.orpha.net/ORDO/Orphanet_101150";
         String foundLabel = "";
-        List<Term> terms = olsClient.getExactTermsByName(iri, null);
+        List<Term> terms = olsClient.getExactTermsByIriString(iri);
         for (Term term : terms){
             if (term.isDefinedOntology()){
                 foundLabel = term.getLabel();
@@ -266,9 +252,28 @@ public class OLSClientTest {
 
         assertTrue(foundLabel.equals("Autosomal recessive dopa-responsive dystonia"));
 
-        //restore olsClient search to it's default query field and field list
-        olsClient.setQueryField(olsClient.DEFAULT_QUERY_FIELD);
-        olsClient.setFieldList(olsClient.DEFAULT_FIELD_LIST);
+    }
 
+    @Test
+    public void testObsolete(){
+        String iri = "http://edamontology.org/data_0007";
+        List<Term> terms = olsClient.getExactTermsByIriStringWithObsolete(iri);
+        Term obsoleteTerm = null;
+
+        if (terms != null && !terms.isEmpty()) {
+            for (Term term : terms) {
+                if (term.isDefinedOntology()) {
+                    obsoleteTerm = term;
+                }
+            }
+            if (obsoleteTerm == null){
+                obsoleteTerm = terms.get(0);
+            }
+        }
+
+        String ontology = obsoleteTerm.getOntologyName();
+        obsoleteTerm = olsClient.retrieveTerm(iri, ontology);
+
+        assertTrue(olsClient.isObsolete(obsoleteTerm));
     }
 }


### PR DESCRIPTION
- Added method getExactTermsByIriString(String iri) to retrieve terms when given the identifier.iri (e.g. http://www.orpha.net/ORDO/Orphanet_101150)

- Added method getExactTermsByIriStringWithObsolete(String iri) that will do the same as above, but will also include obsolete terms

- Separated Term and ObsoleteTerm 

-Added Term retriever, that gets the Term as queried in OLS: http://www.ebi.ac.uk/ols/api/ontologies/edam/terms?iri=http://edamontology.org/data_0007

- Added isObsolete method that retrieves the Term from OLS and checks if it is an instance of ObsoleteTerm