### PR TITLE
getTermByIRIId() fixed

### DIFF
--- a/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClient.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClient.java
@@ -170,7 +170,7 @@ public class OLSClient implements Client {
     /**
      * Return a Term for an IRI identifier and the ontology Identifier.
      *
-     * @param iriId      RI Identifier in OLS
+     * @param iriId      IRI Identifier in OLS
      * @param ontologyId ontology Identifier
      * @return Term result term from OLS
      * @throws RestClientException if there are problems connecting to the REST service.

--- a/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClient.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClient.java
@@ -185,9 +185,9 @@ public class OLSClient implements Client {
         UriComponents components = builder.build(true);
         URI uri = components.toUri();
         logger.debug("" + uri);
-        TermQuery termQuery = this.restTemplate.getForObject(uri, TermQuery.class);
-        if (termQuery != null && termQuery.getTerms() != null && termQuery.getTerms().length == 1) {
-            result =  termQuery.getTerms()[0];
+        Term term = this.restTemplate.getForObject(uri, Term.class);
+        if (term != null) {
+            result = term;
         }
         return result;
     }

--- a/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClient.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClient.java
@@ -4,6 +4,8 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 import uk.ac.ebi.pride.utilities.ols.web.service.config.AbstractOLSWsConfig;
 import uk.ac.ebi.pride.utilities.ols.web.service.model.*;
 import uk.ac.ebi.pride.utilities.ols.web.service.utils.Constants;
@@ -166,27 +168,28 @@ public class OLSClient implements Client {
     }
 
     /**
-     * Return a Term for a short name Identifier and the ontology Identifier.
+     * Return a Term for an IRI identifier and the ontology Identifier.
      *
-     * @param iriId      short term Identifier in OLS
+     * @param iriId      RI Identifier in OLS
      * @param ontologyId ontology Identifier
-     * @return Term
+     * @return Term result term from OLS
      * @throws RestClientException if there are problems connecting to the REST service.
      */
     public Term getTermByIRIId(String iriId, String ontologyId) throws RestClientException {
-
-        String url = String.format("%s://%s/api/ontologies/%s/terms/%s",
-                config.getProtocol(), config.getHostName(), ontologyId, iriId);
-
-        logger.debug(url);
-
-        TermQuery result = this.restTemplate.getForObject(url, TermQuery.class);
-
-        if (result != null && result.getTerms() != null && result.getTerms().length == 1) {
-            return result.getTerms()[0];
+        Term result = null;
+        iriId = iriId.replaceAll(":", "%253A");
+        iriId = iriId.replaceAll("/", "%252F");
+        String url = config.getProtocol() + "://" + config.getHostName() +
+            "api/ontologies/" + ontologyId.toLowerCase() + "/terms/";
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url).path(iriId);
+        UriComponents components = builder.build(true);
+        URI uri = components.toUri();
+        logger.debug("" + uri);
+        TermQuery termQuery = this.restTemplate.getForObject(uri, TermQuery.class);
+        if (termQuery != null && termQuery.getTerms() != null && termQuery.getTerms().length == 1) {
+            result =  termQuery.getTerms()[0];
         }
-
-        return null;
+        return result;
     }
 
     public List<String> getTermDescription(Identifier termId, String ontologyId) throws RestClientException {

--- a/src/test/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClientTest.java
+++ b/src/test/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClientTest.java
@@ -262,4 +262,10 @@ public class OLSClientTest {
         obsoleteTerm = olsClient.retrieveTerm(iri, ontology);
         assertTrue(olsClient.isObsolete(obsoleteTerm));
     }
+
+    @Test public void testGetTermByIriId() throws Exception {
+        Term term = olsClient.getTermById(new Identifier("GO:0031145", Identifier.IdentifierType.OBO), "GO");
+        olsClient.getTermByIRIId(term.getIri().getIdentifier(), term.getOntologyPrefix());
+        Assert.assertTrue(term.getLabel().equalsIgnoreCase("anaphase-promoting complex-dependent catabolic process"));
+    }
 }

--- a/src/test/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClientTest.java
+++ b/src/test/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClientTest.java
@@ -265,7 +265,7 @@ public class OLSClientTest {
 
     @Test public void testGetTermByIriId() throws Exception {
         Term term = olsClient.getTermById(new Identifier("GO:0031145", Identifier.IdentifierType.OBO), "GO");
-        olsClient.getTermByIRIId(term.getIri().getIdentifier(), term.getOntologyPrefix());
+        term = olsClient.getTermByIRIId(term.getIri().getIdentifier(), term.getOntologyPrefix());
         Assert.assertTrue(term.getLabel().equalsIgnoreCase("anaphase-promoting complex-dependent catabolic process"));
     }
 }


### PR DESCRIPTION
The getTermByIRIId method was not working at all before, and the Javadoc was wrong. This has been fixed now in terms of the base URL, properly encoded special characters for the pain IRI parameter, improved readability, fixed the Javadoc comment, and added a unit test to improve code coverage.