### PR TITLE
Updated URL to https

### DIFF
--- a/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/config/OLSWsConfig.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/config/OLSWsConfig.java
@@ -8,11 +8,11 @@ import uk.ac.ebi.pride.utilities.ols.web.service.utils.Constants;
 public class OLSWsConfig extends AbstractOLSWsConfig {
 
     public OLSWsConfig() {
-        super(Constants.OLS_PROTOCOL, Constants.OLS_SERVER);
+        super(Constants.OLS_SECURE_PROTOCOL, Constants.OLS_SERVER);
     }
 
     public OLSWsConfig(String hostName){
-        super(Constants.OLS_PROTOCOL, hostName);
+        super(Constants.OLS_SECURE_PROTOCOL, hostName);
     }
 
     public OLSWsConfig(String protocol, String hostName){

--- a/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/config/OLSWsConfigProd.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/config/OLSWsConfigProd.java
@@ -8,6 +8,6 @@ import uk.ac.ebi.pride.utilities.ols.web.service.utils.Constants;
 public class OLSWsConfigProd extends AbstractOLSWsConfig {
 
     public OLSWsConfigProd() {
-        super(Constants.OLS_PROTOCOL, Constants.OLS_SERVER);
+        super(Constants.OLS_SECURE_PROTOCOL, Constants.OLS_SERVER);
     }
 }

--- a/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/utils/Constants.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/ols/web/service/utils/Constants.java
@@ -10,6 +10,7 @@ public class Constants {
     public static final int TERM_PAGE_SIZE = 1000;
     public static final String REFERENCE_SEPARATOR = ":";
     public static final String OLS_PROTOCOL = "http";
+    public static final String OLS_SECURE_PROTOCOL = "https";
     public static final String OLS_SERVER = "www.ebi.ac.uk/ols/";
     public static final String OLS_SERVER_DEV = "wwwdev.ebi.ac.uk/ols/";
 }


### PR DESCRIPTION
Creates a new constant for https. Currently the default configuration
doesn’t work after the EBI redirection. The body of the msg is empty
because is only the redirection header with the 30. It makes the old dialog fail too.